### PR TITLE
perf(dashboard): reduce DB calls and latency

### DIFF
--- a/hooks/useDashboardData.ts
+++ b/hooks/useDashboardData.ts
@@ -32,12 +32,13 @@ export function useDashboardData() {
     '/api/dashboard',
     fetcher,
     {
-      revalidateOnFocus: true, // Revalidate on window focus (changed from false)
-      revalidateOnReconnect: true, // Revalidate on reconnect
-      refreshInterval: 60000, // Auto refresh every minute
-      dedupingInterval: 2000, // Dedupe requests within 2 seconds (reduced from 5000)
-      errorRetryCount: 3, // Retry failed requests 3 times
-      errorRetryInterval: 3000, // Wait 3 seconds between retries (reduced from 5000)
+      // Reduce background refetch pressure; rely on persisted cache + manual refresh
+      revalidateOnFocus: false,
+      revalidateOnReconnect: true,
+      refreshInterval: 180000, // 3 minutes; set 0 to disable if desired
+      dedupingInterval: 5000,
+      errorRetryCount: 3,
+      errorRetryInterval: 3000,
     }
   );
 


### PR DESCRIPTION
- Use session uuid directly (no extra user lookup)
- Parallelize wallet/usage/package/user queries
- Parallelize credit stats (today/week/month + ranking)
- Remove redundant trend fetch from /api/dashboard
- Optimize prev-period aggregation in consumption-trends
- Lower SWR refresh pressure for dashboard data