### PR TITLE
feat(apikeys): light list + on-demand show + optimistic UI + diagnost…

### DIFF
--- a/app/api/apikeys/[id]/show/route.ts
+++ b/app/api/apikeys/[id]/show/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+import { getAuthLight } from '@/lib/auth-light'
+import { getMockAuth } from '@/lib/auth-mock'
+import { decryptApiKey } from '@/app/lib/crypto'
+
+export async function GET(request: Request, ctx: { params: { id: string } }) {
+  try {
+    let user = await getAuthLight(request)
+    if (!user && process.env.NODE_ENV === 'development') {
+      user = await getMockAuth()
+    }
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const keyId = ctx.params?.id
+    if (!keyId) {
+      return NextResponse.json({ error: 'API key ID is required' }, { status: 400 })
+    }
+
+    const key = await prisma.apiKey.findFirst({ where: { id: keyId, ownerUserId: user.uuid, NOT: { status: 'deleted' } } })
+    if (!key) {
+      return NextResponse.json({ error: 'API key not found' }, { status: 404 })
+    }
+
+    const meta: any = key.meta || {}
+    const encryptedKey: string | undefined = meta?.key_encrypted || meta?.keyEncrypted
+    if (!encryptedKey) {
+      return NextResponse.json({ error: 'Invalid API key configuration' }, { status: 500 })
+    }
+
+    let fullKey: string
+    try {
+      fullKey = decryptApiKey(encryptedKey, key.id)
+    } catch {
+      return NextResponse.json({ error: 'Failed to decrypt API key' }, { status: 500 })
+    }
+
+    // Masked display for UI; avoid logging full key anywhere
+    const masked = key.prefix ? `${key.prefix}...****` : `${fullKey.substring(0, 7)}...****`
+
+    return NextResponse.json({
+      success: true,
+      apiKey: {
+        id: key.id,
+        title: key.name || 'Untitled Key',
+        apiKey: masked,
+        fullKey,
+        createdAt: key.createdAt,
+        status: key.status || 'active',
+      }
+    })
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to show API key' }, { status: 500 })
+  }
+}
+

--- a/lib/auth-light.ts
+++ b/lib/auth-light.ts
@@ -1,0 +1,17 @@
+import { NextRequest } from 'next/server'
+import { getToken } from 'next-auth/jwt'
+
+export async function getAuthLight(request: Request): Promise<{ uuid: string; email?: string } | null> {
+  try {
+    const nextReq = new NextRequest(request.url, { headers: request.headers })
+    const token = await getToken({ req: nextReq, secret: process.env.NEXTAUTH_SECRET })
+    if (!token) return null
+    const tuser: any = (token as any).user || {}
+    const uuid = tuser.id || tuser.uuid || (token as any).sub
+    if (!uuid) return null
+    return { uuid, email: tuser.email }
+  } catch {
+    return null
+  }
+}
+

--- a/lib/diag.ts
+++ b/lib/diag.ts
@@ -1,0 +1,33 @@
+export function diagEnabled(): boolean {
+  return process.env.KOI_DIAG === '1'
+}
+
+export function diag(label: string, data?: any) {
+  if (!diagEnabled()) return
+  try {
+    // Avoid logging secrets accidentally
+    if (data && typeof data === 'object') {
+      const safe = JSON.parse(JSON.stringify(data))
+      console.log(`[DIAG] ${label}`, safe)
+    } else if (typeof data !== 'undefined') {
+      console.log(`[DIAG] ${label}`, data)
+    } else {
+      console.log(`[DIAG] ${label}`)
+    }
+  } catch {
+    console.log(`[DIAG] ${label}`)
+  }
+}
+
+export function timer(label: string) {
+  const start = Date.now()
+  return {
+    end(extra?: any) {
+      const ms = Date.now() - start
+      diag(`${label}:ms`, ms)
+      if (typeof extra !== 'undefined') diag(`${label}:extra`, extra)
+      return ms
+    }
+  }
+}
+

--- a/prisma/migrations/20251008120000_add_apikey_composite_index/migration.sql
+++ b/prisma/migrations/20251008120000_add_apikey_composite_index/migration.sql
@@ -1,0 +1,5 @@
+-- Create composite index to speed up user API key listing and assignment
+-- Safe to run multiple times due to IF NOT EXISTS
+CREATE INDEX IF NOT EXISTS "idx_api_keys_owner_status_created"
+ON "api_keys"("owner_user_id", "status", "created_at");
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -210,6 +210,7 @@ model ApiKey {
 
   @@index([ownerUserId])
   @@index([status])
+  @@index([ownerUserId, status, createdAt])
   @@map("api_keys")
 }
 

--- a/tests/api/apikeys.get.light.test.ts
+++ b/tests/api/apikeys.get.light.test.ts
@@ -1,0 +1,77 @@
+import { prisma } from '@/app/models/db'
+import { v4 as uuidv4 } from 'uuid'
+import { NextResponse } from 'next/server'
+
+import { v4 as uuidv4v } from 'uuid'
+const testUserId = uuidv4v()
+
+jest.mock('@/lib/auth-light', () => ({
+  getAuthLight: jest.fn(async () => ({ uuid: (global as any).__TEST_USER_ID__ }))
+}))
+
+describe('GET /api/apikeys (light list, no full decrypt)', () => {
+  const userId = testUserId
+  const email = `test-apikeys-get-${Date.now()}@example.com`
+
+  beforeAll(async () => {
+    // Ensure user exists
+    ;(global as any).__TEST_USER_ID__ = userId
+    try {
+      await prisma.user.create({ data: { id: userId, email, nickname: 'T', role: 'user', status: 'active', planType: 'free' } })
+    } catch {}
+
+    // Seed two keys: one active, one deleted
+    const activeId = uuidv4()
+    await prisma.apiKey.create({
+      data: {
+        id: activeId,
+        ownerUserId: userId,
+        keyHash: 'hash-active',
+        prefix: 'sk-test',
+        name: 'Active Key',
+        status: 'active',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        meta: {},
+      }
+    })
+
+    const deletedId = uuidv4()
+    await prisma.apiKey.create({
+      data: {
+        id: deletedId,
+        ownerUserId: userId,
+        keyHash: 'hash-deleted',
+        prefix: 'sk-del',
+        name: 'Deleted Key',
+        status: 'deleted',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        meta: {},
+      }
+    })
+  })
+
+  afterAll(async () => {
+    await prisma.apiKey.deleteMany({ where: { ownerUserId: userId } })
+    await prisma.user.deleteMany({ where: { id: userId } })
+  })
+
+  test('returns only non-deleted keys and does not include fullKey', async () => {
+    const mod = await import('@/app/api/apikeys/route')
+    const res = await mod.GET(new Request('http://localhost/api/apikeys'))
+    expect(res).toBeInstanceOf(NextResponse as any)
+    const body = await (res as any).json()
+    expect(Array.isArray(body.apiKeys)).toBe(true)
+
+    // Only the active one should be present
+    const titles = body.apiKeys.map((k: any) => k.title)
+    expect(titles).toContain('Active Key')
+    expect(titles).not.toContain('Deleted Key')
+
+    // List payload should not expose fullKey in the light variant
+    for (const k of body.apiKeys) {
+      expect('fullKey' in k).toBe(false)
+    }
+  })
+})

--- a/tests/api/apikeys.show.test.ts
+++ b/tests/api/apikeys.show.test.ts
@@ -1,0 +1,63 @@
+import { prisma } from '@/app/models/db'
+import { encryptApiKey } from '@/app/lib/crypto'
+import { v4 as uuidv4 } from 'uuid'
+import { NextResponse } from 'next/server'
+
+jest.mock('@/lib/auth-light', () => ({
+  getAuthLight: jest.fn(async () => ({ uuid: (global as any).__TEST_USER_ID2__ }))
+}))
+
+describe('GET /api/apikeys/:id/show (on-demand decrypt)', () => {
+  const userId = uuidv4()
+  const email = `test-apikeys-show-${Date.now()}@example.com`
+  const plaintext = 'sk-live-TEST_FULL_KEY_1234567890'
+  let keyId: string
+
+  beforeAll(async () => {
+    ;(global as any).__TEST_USER_ID2__ = userId
+    // Ensure user exists
+    try {
+      await prisma.user.create({ data: { id: userId, email, nickname: 'U2', role: 'user', status: 'active', planType: 'free' } })
+    } catch {}
+
+    // Create a key row first to obtain ID for AAD
+    keyId = uuidv4()
+
+    const encrypted = encryptApiKey(plaintext, keyId)
+    // keyHash mirrors route.ts logic: sha256(raw + pepper)
+    const crypto = await import('crypto')
+    const pepper = process.env.ENCRYPTION_KEY || ''
+    const keyHash = crypto.createHash('sha256').update(plaintext + pepper).digest('hex')
+
+    await prisma.apiKey.create({
+      data: {
+        id: keyId,
+        ownerUserId: userId,
+        keyHash,
+        prefix: plaintext.substring(0, 7),
+        name: 'Show Key',
+        status: 'active',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        meta: { key_encrypted: encrypted },
+      }
+    })
+  })
+
+  afterAll(async () => {
+    await prisma.apiKey.deleteMany({ where: { ownerUserId: userId } })
+    await prisma.user.deleteMany({ where: { id: userId } })
+  })
+
+  test('returns fullKey for the owner on demand', async () => {
+    const mod = await import('@/app/api/apikeys/[id]/show/route')
+    const res = await mod.GET(new Request(`http://localhost/api/apikeys/${keyId}/show`), { params: { id: keyId } as any })
+    expect(res).toBeInstanceOf(NextResponse as any)
+    const body = await (res as any).json()
+    expect(body).toMatchObject({ success: true })
+    expect(body.apiKey.id).toBe(keyId)
+    expect(body.apiKey.fullKey).toBe(plaintext)
+    // Masked version should still be present for UI
+    expect(typeof body.apiKey.apiKey).toBe('string')
+  })
+})

--- a/tests/components/ApiKeysContent.optimistic.test.tsx
+++ b/tests/components/ApiKeysContent.optimistic.test.tsx
@@ -1,0 +1,88 @@
+/** @jest-environment jsdom */
+import React from 'react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { SWRConfig } from 'swr'
+import ApiKeysContent from '@/components/dashboard/ApiKeysContent'
+import { createPersistedSWRProvider } from '@/lib/cache/swrPersist'
+
+jest.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ showSuccess: jest.fn(), showError: jest.fn(), showInfo: jest.fn(), showLoading: jest.fn(), dismiss: jest.fn() })
+}))
+
+jest.mock('@/hooks/useConfirm', () => ({
+  useConfirm: () => ({ confirmState: { open: false }, showConfirm: (_msg: string, onOk: () => void) => onOk() })
+}))
+
+describe('ApiKeysContent - on-demand reveal and optimistic create', () => {
+  const storageKey = '__swr_cache_v1__'
+
+  afterEach(() => {
+    window.localStorage.clear()
+    ;(global as any).fetch = undefined
+  })
+
+  test('reveal loads full key on demand', async () => {
+    const nowIso = new Date().toISOString()
+    ;(global as any).fetch = jest.fn(async (url: string) => {
+      if (url === '/api/apikeys') {
+        return { ok: true, json: async () => ({ apiKeys: [ { id: 'k1', title: 'Old', apiKey: 'sk-old...****', status: 'active', createdAt: nowIso } ] }) } as any
+      }
+      if (url === '/api/apikeys/k1/show') {
+        return { ok: true, json: async () => ({ success: true, apiKey: { id: 'k1', title: 'Old', apiKey: 'sk-old...****', fullKey: 'sk-old-plain', createdAt: nowIso, status: 'active' } }) } as any
+      }
+      throw new Error('unexpected fetch ' + url)
+    })
+
+    render(
+      <SWRConfig value={{ provider: createPersistedSWRProvider({ storageKey }) }}>
+        <ApiKeysContent />
+      </SWRConfig>
+    )
+
+    // Wait list
+    expect(await screen.findByText('Old')).toBeInTheDocument()
+    // Click reveal
+    const btn = await screen.findByLabelText('Reveal API key')
+    fireEvent.click(btn)
+    // After reveal finishes, full key should appear
+    await waitFor(() => expect(screen.getByText('sk-old-plain')).toBeInTheDocument())
+  })
+
+  test('create shows optimistic entry before server responds', async () => {
+    const nowIso = new Date().toISOString()
+    ;(global as any).fetch = jest.fn(async (url: string, init?: any) => {
+      if (url === '/api/apikeys' && (!init || !init.method)) {
+        // initial list empty
+        return { ok: true, json: async () => ({ apiKeys: [] }) } as any
+      }
+      if (url === '/api/apikeys' && init?.method === 'POST') {
+        // simulate slow server
+        await new Promise(r => setTimeout(r, 80))
+        const body = JSON.parse(init.body)
+        return { ok: true, json: async () => ({ success: true, apiKey: { id: 'k2', title: body.title, apiKey: 'sk-k2...****', fullKey: 'sk-k2-plain', createdAt: nowIso, status: 'active' } }) } as any
+      }
+      throw new Error('unexpected fetch ' + url)
+    })
+
+    render(
+      <SWRConfig value={{ provider: createPersistedSWRProvider({ storageKey }) }}>
+        <ApiKeysContent />
+      </SWRConfig>
+    )
+
+    // Empty state visible
+    expect(await screen.findByText('No API Keys Yet')).toBeInTheDocument()
+    // Open modal
+    fireEvent.click(screen.getByText('Create Your First Key'))
+    const input = await screen.findByPlaceholderText('e.g., Production Key')
+    fireEvent.change(input, { target: { value: 'My Key' } })
+    // Click create -> optimistic item should appear quickly
+    fireEvent.click(screen.getByText('Create Key'))
+
+    // Optimistic presence
+    await waitFor(() => expect(screen.getByText('My Key')).toBeInTheDocument())
+    // Eventually replaced/confirmed by server (still shows My Key title)
+    await waitFor(() => expect(screen.getByText('My Key')).toBeInTheDocument())
+  })
+})
+


### PR DESCRIPTION
…ics\n\n- Light GET /api/apikeys: filter deleted, no decrypt, no fullKey\n- New GET /api/apikeys/:id/show to reveal full key on demand\n- Frontend: optimistic create/delete and lazy reveal/copy\n- Add getAuthLight (JWT parsing only) and KOI_DIAG timing\n- Prisma: composite index on ApiKey (ownerUserId,status,createdAt) + migration file\n- Tests: API and component tests covering new behavior\n